### PR TITLE
XML Compatibility

### DIFF
--- a/jquery.inlineedit.js
+++ b/jquery.inlineedit.js
@@ -223,7 +223,7 @@ $.inlineEdit.prototype = {
             return '<textarea>'+ value.replace(/<br\s?\/?>/g,"\n") +'</textarea>' + this.buttonHtml( { before: '<br />' } );
         },
         input: function( value ) {
-            return '<input type="text" value="'+ value.replace(/(\u0022)+/g, '') +'">' + this.buttonHtml();
+            return '<input type="text" value="'+ value.replace(/(\u0022)+/g, '') +'"/>' + this.buttonHtml();
         }
     },
 


### PR DESCRIPTION
Basically, the problem is that jQuery cannot use the `jQuery.html(content)` cannot work with malformed XML when in XML mode. There was just a minor flaw in the code, but it almost brought me to rip off my hair by myself today...
