### PR TITLE
Fixes select-extension bug in firefox

### DIFF
--- a/jquery.inlineedit.js
+++ b/jquery.inlineedit.js
@@ -32,8 +32,7 @@ $.fn.inlineEdit = function( options ) {
                 mutated = !!editableElement.length;
 
             widget.element.removeClass( widget.options.hover );
-            
-            if ( event.target !== editableElement[0] ) {
+            if ( editableElement[0] != event.target  && editableElement.has(event.target).length == 0 ) {
                 switch ( event.type ) {
                     case 'click':
                         widget[ mutated ? 'mutate' : 'init' ]();
@@ -213,7 +212,7 @@ $.inlineEdit.prototype = {
         
         return o.before + o.buttons + o.after;
     },
-    
+
     save: function( elem, event ) {
         var $control = this.element.find( this.options.control ), 
             hash = {


### PR DESCRIPTION
This fixes the firefox bug, for the select extension.

All I am doing is checking whether the event.target is within my editable element.

This is required for the select extension
