### PR TITLE
Fix XSS 

### DIFF
--- a/demos/save.php
+++ b/demos/save.php
@@ -10,7 +10,7 @@ switch ($action) {
     // retrieve data
     case 'get':
         //echo file_get_contents('data.txt');
-        echo $data;
+        echo htmlentities($data);
         break;
 
     // save data

--- a/demos/save.php
+++ b/demos/save.php
@@ -1,9 +1,9 @@
 <?php
-$action = isset($_POST) && $_POST['action'] ? $_POST['action'] : 'get';
-$value  = isset($_POST) && $_POST['value'] ? $_POST['value'] : '';
+$action = isset($_POST['action']) && $_POST['action'] ? $_POST['action'] : 'get';
+$value  = isset($_POST['value']) && $_POST['value'] ? $_POST['value'] : '';
 
 session_start();
-$data = isset($_SESSION) && $_SESSION['data'] ? $_SESSION['data'] : 'Hello World!';
+$data = isset($_SESSION['data']) && $_SESSION['data'] ? $_SESSION['data'] : 'Hello World!';
 
 switch ($action) {
 

--- a/jquery.inlineedit.js
+++ b/jquery.inlineedit.js
@@ -229,7 +229,6 @@ $.inlineEdit.prototype = {
     save: function( elem, event ) {
         var $control = this.element.find( this.options.control ), 
             hash = {
-                //value: this.encodeHtml( $control.val() )
                 value: $control.val()
             };
 

--- a/jquery.inlineedit.js
+++ b/jquery.inlineedit.js
@@ -74,20 +74,20 @@ $.inlineEdit = function( elem, options ) {
     // the original element
     this.element = $( elem );
 
-}
+};
 
 // plugin instance
 $.inlineEdit.getInstance = function( elem, options ) {
     return ( $.inlineEdit.initialised( elem ) ) 
     ? $( elem ).data( 'widget' + namespace )
     : new $.inlineEdit( elem, options );
-}
+};
 
 // check if plugin initialised
 $.inlineEdit.initialised = function( elem ) {
     var init = $( elem ).data( 'init' + namespace );
     return init !== undefined && init !== null ? true : false;
-}
+};
 
 // plugin defaults
 $.inlineEdit.defaults = {
@@ -193,7 +193,7 @@ $.inlineEdit.prototype = {
         if ( arguments.length ) {
             var value = newValue == this.placeholderHtml() ? '' : newValue;
             this._debug('value:','to save', value);
-            this.element.data( 'value' + namespace, value && this.encodeHtml( this.nl2br(value) ) );
+            this.element.data( 'value' + namespace, value && ( this.nl2br(value) ) );
             this._debug('value:','saved', this.element.data( 'value' + namespace ));
         }
         return this._decodeHtml( this.element.data( 'value' + namespace) );
@@ -229,7 +229,8 @@ $.inlineEdit.prototype = {
     save: function( elem, event ) {
         var $control = this.element.find( this.options.control ), 
             hash = {
-                value: this.encodeHtml( $control.val() )
+                //value: this.encodeHtml( $control.val() )
+                value: $control.val()
             };
 
         this._debug('save:',"Saving...");
@@ -268,7 +269,7 @@ $.inlineEdit.prototype = {
 
         this.timer = window.setTimeout( function() {
             self._debug( 'change:', 'Change', self.value() );
-            self.element.html( self.value() || self.placeholderHtml() );
+            self.element.html( self.encodeHtml(self.value()) || self.placeholderHtml() );
             self.element.removeClass( self.options.hover );
             self.element.removeClass( self.options.editInProgress );
             self._callback( 'change', [event, self] );
@@ -292,8 +293,8 @@ $.inlineEdit.prototype = {
     
     encodeHtml: function( s ) {
         var encoding = [
-              {key: /</g, value: '<'},
-              {key: />/g, value: '>'},
+              {key: /</g, value: '&lt;'},
+              {key: />/g, value: '&gt;'},
               {key: /"/g, value: '&quot;'}
             ],
             value = s;
@@ -327,6 +328,8 @@ $.inlineEdit.prototype = {
 
     _decodeHtml: function( encoded ) {
         var decoded = encoded.replace(/&quot;/g,'"');
+        decoded = decoded.replace(/&lt;/g,'<');
+        decoded = decoded.replace(/&gt;/g,'>');
         this._debug('_decodeHtml:', decoded);
         return decoded;
     }


### PR DESCRIPTION
Problem

jquery.html() will run any js code that is passed in to it.
For example, 
on the demo http://www.yelotofu.com/labs/jquery/snippets/inlineEdit/demo_final.html
enter:

```
<script>alert('xss')</script>
```

Solution
- Changed code to convert HTML to entities. 
- When saving to the server, make sure that entity decoded code is sent to the server.

Note: the br2nl feature is a little tricky. Left it as it. Perhaps this could be improved by replacing the textarea with a div and contenteditable="true" ?
